### PR TITLE
Fix startup issues

### DIFF
--- a/lib/flickwerk.rb
+++ b/lib/flickwerk.rb
@@ -9,6 +9,7 @@ module Flickwerk
 
   mattr_accessor :patch_paths, default: []
   mattr_accessor :patches, default: Hash.new([])
+  mattr_accessor :aliases, default: {}
 
   def self.included(engine)
     engine.root.glob("app/patches/*").each do |path|
@@ -17,6 +18,7 @@ module Flickwerk
   end
 
   def self.patch(class_name, with:)
-    patches[class_name] += [with]
+    klass_name = aliases[class_name] || class_name
+    patches[klass_name] += [with]
   end
 end

--- a/lib/flickwerk/railtie.rb
+++ b/lib/flickwerk/railtie.rb
@@ -10,13 +10,17 @@ class Flickwerk::Railtie < Rails::Railtie
     end
   end
 
-  initializer "flickwerk.find_patches", after: :setup_main_autoloader do
-    Flickwerk.patch_paths.each do |path|
-      Flickwerk::PatchFinder.new(path).call
+  initializer "flickwerk.find_patches" do |app|
+    app.config.to_prepare do
+      Flickwerk.patch_paths.each do |path|
+        Flickwerk::PatchFinder.new(path).call
+      end
     end
   end
 
-  initializer "flickwerk.add_patches", after: "flickwerk.find_patches" do
-    Flickwerk::PatchLoader.call
+  initializer "flickwerk.add_patches", after: "flickwerk.find_patches" do |app|
+    app.config.to_prepare do
+      Flickwerk::PatchLoader.call
+    end
   end
 end

--- a/test/dummy_app/app/models/ui/button.rb
+++ b/test/dummy_app/app/models/ui/button.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module UI
+  class Button
+    def click
+      "Button clicked!"
+    end
+  end
+end

--- a/test/dummy_app/app/patches/models/user_patch.rb
+++ b/test/dummy_app/app/patches/models/user_patch.rb
@@ -7,5 +7,5 @@ module UserPatch
     26
   end
 
-  User.prepend(self)
+  DummyApp.user_class.prepend(self)
 end

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -2,9 +2,14 @@ require "rails"
 require "flickwerk/railtie"
 
 module DummyApp
+  def self.user_class
+    User
+  end
+
   class Application < ::Rails::Application
     config.root = File.expand_path("../", __dir__)
     include Flickwerk
+    Flickwerk.aliases["DummyApp.user_class"] = "User"
     config.autoload_paths << File.expand_path("../app/models", __dir__)
 
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")

--- a/test/dummy_app/config/initializers/inflections.rb
+++ b/test/dummy_app/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActiveSupport::Inflector.inflections { |inflect| inflect.acronym "UI" }

--- a/test/test_flickwerk.rb
+++ b/test/test_flickwerk.rb
@@ -61,4 +61,12 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     Flickwerk.patch("User", with: "UserPatch")
     assert_equal ["UserPatch"], Flickwerk.patches["User"]
   end
+
+  test "acronyms still work" do
+    boot
+
+    assert UI::Button
+    assert UI::Button.new.respond_to?(:click)
+    assert_equal "Button clicked!", UI::Button.new.click
+  end
 end


### PR DESCRIPTION
Prior to these commits, Flickwerk patches were evaluated as part of the initializer chain. These commit move them to the `config.to_prepare` hook, which runs after all initializers. Running `autoloader.cpath_expected_at(const_string)` led to undesirable results when, for example, initializers definining inflections had not run before. 

This change removes the clearly defined spot to manipulate the set of patches before loading them, which we used in solidus_support 0.11 for transforming keys with `"Spree.user_class"` to whatever the actual user class was. In order to be able to have that feature anyways, we add an `aliases` attribute that can be filled early-on with a mapping, and `Flickwerk.patch` will respect that mapping. That way, `Flickwerk.patches` won't contain un-constantizable classes in the first place.