### PR TITLE
Support patching singleton classes

### DIFF
--- a/lib/flickwerk/patch_finder.rb
+++ b/lib/flickwerk/patch_finder.rb
@@ -2,7 +2,7 @@
 
 module Flickwerk
   class PatchFinder
-    DECORATED_CLASS_PATTERN = /(?:::)?(?<decorated_class>[\w.:]+)\.prepend[\s(]/
+    DECORATED_CLASS_PATTERN = /(?:::)?(?<decorated_class>[\w.:]+?)(?:\.singleton_class)?\.prepend[\s(]/
 
     attr_reader :path, :autoloader
 

--- a/test/dummy_app/app/patches/models/user_class_methods_patch.rb
+++ b/test/dummy_app/app/patches/models/user_class_methods_patch.rb
@@ -1,0 +1,7 @@
+module UserClassMethodsPatch
+  def address
+    "The outer rim"
+  end
+
+  DummyApp.user_class.singleton_class.prepend(self)
+end

--- a/test/test_flickwerk.rb
+++ b/test/test_flickwerk.rb
@@ -69,4 +69,11 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert UI::Button.new.respond_to?(:click)
     assert_equal "Button clicked!", UI::Button.new.click
   end
+
+  test "singleton classes can be patched" do
+    boot
+
+    assert User
+    assert "The outer rim", User.address
+  end
 end


### PR DESCRIPTION
If we want to patch class methods and still be able to call super, we have to use the classes "singleton_class". This addition to the regexp in the patch finder allows that.