### PR TITLE
Fix loading the patchify class

### DIFF
--- a/lib/flickwerk/patchify.rb
+++ b/lib/flickwerk/patchify.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "active_support/core_ext/string"
 
 module Flickwerk


### PR DESCRIPTION
In Rails 7.1, the core extensions for string contain a deprecation, and thus things break when not loading the active_support gem first.