### PR TITLE
Change autoload paths directly

### DIFF
--- a/lib/flickwerk.rb
+++ b/lib/flickwerk.rb
@@ -12,9 +12,9 @@ module Flickwerk
   mattr_accessor :aliases, default: {}
 
   def self.included(engine)
-    engine.root.glob("app/patches/*").each do |path|
-      Flickwerk.patch_paths << path
-    end
+    engine_patch_paths = engine.root.glob("app/patches/*")
+    engine.config.autoload_paths += engine_patch_paths
+    Flickwerk.patch_paths += engine_patch_paths
   end
 
   def self.patch(class_name, with:)

--- a/lib/flickwerk/railtie.rb
+++ b/lib/flickwerk/railtie.rb
@@ -5,12 +5,6 @@ require "flickwerk/patch_loader"
 require "rails/railtie"
 
 class Flickwerk::Railtie < Rails::Railtie
-  initializer "flickwerk.add_paths", before: :set_autoload_paths do |app|
-    Flickwerk.patch_paths.each do |path|
-      app.config.autoload_paths << path
-    end
-  end
-
   initializer "flickwerk.find_patches" do |app|
     app.reloader.to_prepare do
       Flickwerk.patch_paths.each do |path|


### PR DESCRIPTION
If we change the autoload paths in an initializer, eager loading does not work.