### PR TITLE
Delay patch finding to before `:eager_load!`

### DIFF
--- a/lib/flickwerk/railtie.rb
+++ b/lib/flickwerk/railtie.rb
@@ -5,7 +5,7 @@ require "flickwerk/patch_loader"
 require "rails/railtie"
 
 class Flickwerk::Railtie < Rails::Railtie
-  initializer "flickwerk.find_patches" do |app|
+  initializer "flickwerk.find_patches", before: :eager_load! do |app|
     app.reloader.to_prepare do
       Flickwerk.patch_paths.each do |path|
         Flickwerk::PatchFinder.new(path).call


### PR DESCRIPTION
Currently, the Flickwerk initializers run at some time, and that works. However, by fixing them to `before: :eager_load!`, we make sure they run late enough to know all about all inflections.