### PR TITLE
Expect patched class to begin with capital letter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on:
   push:
@@ -8,14 +8,13 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Test with Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         ruby:
           - '3.2.6'
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -23,5 +22,22 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run the default task
+      - name: Run tests
         run: bundle exec rake
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint with Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          - '3.2.6'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Lint code
+        run: bundle exec rake standard

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ Minitest::TestTask.create
 
 require "standard/rake"
 
-task default: %i[test standard]
+task default: %i[test]

--- a/lib/flickwerk.rb
+++ b/lib/flickwerk.rb
@@ -8,7 +8,7 @@ module Flickwerk
   class Error < StandardError; end
 
   mattr_accessor :patch_paths, default: []
-  mattr_accessor :patches, default: Hash.new([])
+  mattr_accessor :patches, default: Hash.new { [] }
   mattr_accessor :aliases, default: {}
 
   def self.included(engine)

--- a/lib/flickwerk/patch_finder.rb
+++ b/lib/flickwerk/patch_finder.rb
@@ -2,7 +2,7 @@
 
 module Flickwerk
   class PatchFinder
-    DECORATED_CLASS_PATTERN = /(?:::)?(?<decorated_class>[\w.:]+?)(?:\.singleton_class)?\.prepend[\s(]/
+    DECORATED_CLASS_PATTERN = /(?:::)?(?<decorated_class>[A-Z][\w.:]+?)(?:\.singleton_class)?\.prepend[\s(]/
 
     attr_reader :path, :autoloader
 

--- a/test/dummy_app/app/patches/models/page_patch.rb
+++ b/test/dummy_app/app/patches/models/page_patch.rb
@@ -1,6 +1,16 @@
 module PagePatch
+  def self.prepended(base)
+    base.prepend(InstanceMethods)
+  end
+
   def title
     "Changed from Host app"
+  end
+
+  module InstanceMethods
+    def name
+      "Homepage"
+    end
   end
 
   ::DummyCms::Page.prepend(self)

--- a/test/test_flickwerk.rb
+++ b/test/test_flickwerk.rb
@@ -76,4 +76,13 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert User
     assert "The outer rim", User.address
   end
+
+  test "prepended base class can be prepended" do
+    require "dummy_cms"
+
+    boot
+
+    assert DummyCms::Page
+    assert_equal [], Flickwerk.patches["base"]
+  end
 end


### PR DESCRIPTION
In order to not consider a prepended base class a patch
we expect the patched class constant to begin with a capital
letter.