### PR TITLE
require fileutils

### DIFF
--- a/lib/flickwerk/patchify.rb
+++ b/lib/flickwerk/patchify.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "active_support"
 require "active_support/core_ext/string"
 


### PR DESCRIPTION
Otherwise `bundle exec patchify` will fail with `FileUtils` not present.

Tested in Ruby 3.4.4