### PR TITLE
feat: Add verbose logging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ end
 
 If you application now has a class `Goodie` with a foreign key to the `spree_orders` table, you can check on those goodies using the familiar `order.goodies` in your application.
 
+### Debugging
+
+In order to debug if a patch was found and if it actually loaded, you can enable verbose mode by either setting `FLICKWERK_VERBOSE=true` as ENV var or by enabling it with `Flickwerk.verbose = true` (ie, in an initializer).
 
 ### Using Flickwerk in Engines
 

--- a/lib/flickwerk.rb
+++ b/lib/flickwerk.rb
@@ -11,6 +11,8 @@ module Flickwerk
   mattr_accessor :patch_paths, default: []
   mattr_accessor :patches, default: Hash.new { [] }
   mattr_accessor :aliases, default: {}
+  mattr_accessor :verbose, default: ENV.fetch("FLICKWERK_VERBOSE", "false") == "true"
+  mattr_accessor :logger, default: Logger.new($stdout)
 
   def self.included(engine)
     engine_patch_paths = engine.root.glob("app/patches/*")
@@ -21,5 +23,9 @@ module Flickwerk
   def self.patch(class_name, with:)
     klass_name = aliases[class_name] || class_name
     patches[klass_name] += [with]
+  end
+
+  def self.log(message)
+    logger.add(Logger::INFO, message, "[flickwerk]")
   end
 end

--- a/lib/flickwerk/patch_finder.rb
+++ b/lib/flickwerk/patch_finder.rb
@@ -23,6 +23,9 @@ module Flickwerk
         matches.uniq.each do |decorated_class|
           # Zeitwerk tells us which constant it expects a file to provide.
           decorator_constant = autoloader.cpath_expected_at(patch_path)
+          if Flickwerk.verbose
+            Flickwerk.log("Found patch for #{decorated_class}: #{decorator_constant} at #{patch_path}")
+          end
           Flickwerk.patch(decorated_class, with: decorator_constant)
         end
       end

--- a/lib/flickwerk/patch_loader.rb
+++ b/lib/flickwerk/patch_loader.rb
@@ -5,6 +5,11 @@ module Flickwerk
     def self.call(autoloader: Rails.autoloaders.main)
       Flickwerk.patches.each do |class_name, decorators|
         autoloader.on_load(class_name) do
+          if Flickwerk.verbose
+            Flickwerk.log(
+              "Loading patches for #{class_name}: #{decorators.map(&:to_s).join(", ")}"
+            )
+          end
           decorators.each(&:constantize)
         end
       end

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -9,6 +9,7 @@ module DummyApp
   class Application < ::Rails::Application
     config.root = File.expand_path("../", __dir__)
     include Flickwerk
+
     Flickwerk.aliases["DummyApp.user_class"] = "User"
     config.autoload_paths << File.expand_path("../app/models", __dir__)
 


### PR DESCRIPTION
Enable verbose logging while loading patches.
It logs to stdout by default. Change it by
setting `Flickwerk.logger` to something else.

Enable verbosity by setting `Flickwerk.verbose = true` or 
by setting `FLICKWERK_VERBOSE=true` in your env.

## Example Log

```
I, [2025-10-22T22:19:44.539468 #64342]  INFO -- [flickwerk]: Loading patches for Spree::LineItem: SolidusVolumePricing::SpreeLineItemPatch, SolidusLegacyPromotions::SpreeLineItemPatch, SolidusLegacyPromotions::SpreeLineItemPatch
```